### PR TITLE
Update RDS ingest & delete queries

### DIFF
--- a/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/DeleteQueryTest.java
+++ b/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/DeleteQueryTest.java
@@ -60,12 +60,13 @@ public class DeleteQueryTest {
     void setUp() throws Exception {
         log.info("Test setUp");
         String insertRecords = """
-            INSERT INTO metadata.document_metadata (uuid, external_reference_uuid, type, pdf_link, status, updated_on, deleted_on)
+            INSERT INTO metadata.document_metadata (uuid, external_reference_uuid, type, pdf_link, status, updated_on, deleted, deleted_on)
             VALUES
-                ('00000000-aaaa-bbbb-cccc-000000000000', '00000000-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', timestamp '2023-03-22 12:01:00'),
-                ('00000001-aaaa-bbbb-cccc-000000000000', '00000001-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-15 12:00:00', timestamp '2023-03-15 12:00:00'),
-                ('00000002-aaaa-bbbb-cccc-000000000000', '00000002-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-14 12:00:00', timestamp '2023-03-14 12:00:00'),
-                ('00000003-aaaa-bbbb-cccc-000000000000', '00000003-aaaa-bbbb-cccc-0000000000e1', 'Email', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', timestamp '2023-03-27 12:00:00');
+                ('00000000-aaaa-bbbb-cccc-000000000000', '00000000-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'True', timestamp '2023-03-22 12:01:00'),
+                ('00000001-aaaa-bbbb-cccc-000000000000', '00000001-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-15 12:00:00', 'True', timestamp '2023-03-15 12:00:00'),
+                ('00000002-aaaa-bbbb-cccc-000000000000', '00000002-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-14 12:00:00', 'True', timestamp '2023-03-14 12:00:00'),
+                ('00000003-aaaa-bbbb-cccc-000000000000', '00000003-aaaa-bbbb-cccc-0000000000e1', 'Email', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'True', timestamp '2023-03-27 12:00:00'),
+                ('00000004-aaaa-bbbb-cccc-000000000000', '00000004-aaaa-bbbb-cccc-0000000000e1', 'Email', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', timestamp '2023-03-27 12:00:00');
             """;
         TestUtils.setUpPostgres(this.jdbcTemplate, insertRecords);
 
@@ -101,8 +102,8 @@ public class DeleteQueryTest {
 
         assertEquals("COMPLETED", jobExecution.getExitStatus().getExitCode());
         List<String> keysConsumed = TestUtils.consumeKafkaMessages(bootstrapServers, deleteTopic, 10);
-        assertEquals(3, keysConsumed.size()); // assert 5 records were written
-        // assert the 5 expected document id's were written (use HashSet to ignore order)
+        assertEquals(3, keysConsumed.size()); // assert 3 records were written
+        // assert the 3 expected document id's were written (use HashSet to ignore order)
         assertEquals(new HashSet<String>(expectedDocs), new HashSet<String>(keysConsumed));
     }
 }

--- a/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/DeleteScenario1Test.java
+++ b/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/DeleteScenario1Test.java
@@ -63,14 +63,14 @@ public class DeleteScenario1Test {
     void setUp() throws Exception {
         log.info("Test setUp");
         String insertRecords = """
-            INSERT INTO metadata.document_metadata (uuid, external_reference_uuid, type, pdf_link, status, updated_on, deleted_on)
+            INSERT INTO metadata.document_metadata (uuid, external_reference_uuid, type, pdf_link, status, updated_on, deleted, deleted_on)
             VALUES
-                ('00000000-aaaa-bbbb-cccc-000000000000', '00000000-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-21 12:00:00', timestamp '2023-03-22 11:00:00'),
-                ('00000001-aaaa-bbbb-cccc-000000000000', '00000001-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file2.pdf', 'UPLOADED', timestamp '2023-03-21 12:00:00', timestamp '2023-03-22 12:00:00'),
-                ('00000002-aaaa-bbbb-cccc-000000000000', '00000002-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file3.pdf', 'UPLOADED', timestamp '2023-03-21 12:00:00', timestamp '2023-03-22 13:00:00'),
-                ('00000003-aaaa-bbbb-cccc-000000000000', '00000003-aaaa-bbbb-cccc-000000000000', 'ORIGINAL', 'decs-file4.pdf', 'UPLOADED', timestamp '2023-03-21 12:00:00', timestamp '2023-03-22 14:00:00'),
-                ('00000004-aaaa-bbbb-cccc-000000000000', '00000004-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file5.pdf', 'UPLOADED', timestamp '2023-03-21 12:00:00', timestamp '2023-03-22 15:00:00'),
-                ('00000005-aaaa-bbbb-cccc-000000000000', '00000005-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file6.pdf', 'UPLOADED', timestamp '2023-03-21 12:00:00', timestamp '2023-03-22 16:00:00');
+                ('00000000-aaaa-bbbb-cccc-000000000000', '00000000-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-21 12:00:00', 'True', timestamp '2023-03-22 11:00:00'),
+                ('00000001-aaaa-bbbb-cccc-000000000000', '00000001-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file2.pdf', 'UPLOADED', timestamp '2023-03-21 12:00:00', 'True', timestamp '2023-03-22 12:00:00'),
+                ('00000002-aaaa-bbbb-cccc-000000000000', '00000002-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file3.pdf', 'UPLOADED', timestamp '2023-03-21 12:00:00', 'True', timestamp '2023-03-22 13:00:00'),
+                ('00000003-aaaa-bbbb-cccc-000000000000', '00000003-aaaa-bbbb-cccc-000000000000', 'ORIGINAL', 'decs-file4.pdf', 'UPLOADED', timestamp '2023-03-21 12:00:00', 'True', timestamp '2023-03-22 14:00:00'),
+                ('00000004-aaaa-bbbb-cccc-000000000000', '00000004-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file5.pdf', 'UPLOADED', timestamp '2023-03-21 12:00:00', 'True', timestamp '2023-03-22 15:00:00'),
+                ('00000005-aaaa-bbbb-cccc-000000000000', '00000005-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file6.pdf', 'UPLOADED', timestamp '2023-03-21 12:00:00', 'True', timestamp '2023-03-22 16:00:00');
             """;
         TestUtils.setUpPostgres(this.jdbcTemplate, insertRecords);
 

--- a/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/IngestQueryTest.java
+++ b/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/IngestQueryTest.java
@@ -122,8 +122,8 @@ public class IngestQueryTest {
         // assert the 5 expected document id's were written (use HashSet to ignore order)
         assertEquals(new HashSet<String>(expectedDocs), new HashSet<String>(keysConsumed));
 
-        // 1 pdf files + 1 related json files (because all pdfLinks in the mock data point to the same file)
-        // + 2 json files (ingest timestamp + delete timestamp)
-        assertEquals(4, TestUtils.countS3Objects("untrusted-bucket", this.endpointURL));
+        // (1 pdf + 1 related json per document) * 8 documents ingested = 16
+        // + 2 pre-existing json files (ingest timestamp + delete timestamp)
+        assertEquals(18, TestUtils.countS3Objects("untrusted-bucket", this.endpointURL));
     }
 }

--- a/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/IngestQueryTest.java
+++ b/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/IngestQueryTest.java
@@ -60,23 +60,24 @@ public class IngestQueryTest {
     void setUp() throws Exception {
         log.info("Test setUp");
         String insertRecords = """
-            INSERT INTO metadata.document_metadata (uuid, external_reference_uuid, type, pdf_link, status, updated_on, deleted_on)
+            INSERT INTO metadata.document_metadata (uuid, external_reference_uuid, type, pdf_link, status, updated_on, deleted, deleted_on)
             VALUES
-                ('00000000-aaaa-bbbb-cccc-000000000000', '00000000-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000001-aaaa-bbbb-cccc-000000000000', '00000001-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'NOTUPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000002-aaaa-bbbb-cccc-000000000000', '00000002-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', NULL, 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000003-aaaa-bbbb-cccc-000000000000', '00000003-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', timestamp '2023-03-22 12:01:00'),
-                ('00000004-aaaa-bbbb-cccc-000000000000', '00000004-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 11:59:59', NULL),
-                ('00000005-aaaa-bbbb-cccc-000000000000', '00000005-aaaa-bbbb-cccc-0000000000a1', 'OTHERTYPE', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000006-aaaa-bbbb-cccc-000000000000', '00000006-aaaa-bbbb-cccc-0000000000a2', 'CONTRIBUTION', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000007-aaaa-bbbb-cccc-000000000000', '00000007-aaaa-bbbb-cccc-0000000000a3', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000008-aaaa-bbbb-cccc-000000000000', '00000008-aaaa-bbbb-cccc-0000000000a4', 'Original Complaint', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000009-aaaa-bbbb-cccc-000000000000', '00000009-aaaa-bbbb-cccc-0000000000a5', 'Contribution Response', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000010-aaaa-bbbb-cccc-000000000000', '00000010-aaaa-bbbb-cccc-0000000000a6', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000011-aaaa-bbbb-cccc-000000000000', '00000011-aaaa-bbbb-cccc-0000000000c5', 'Complaint leaflet', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000012-aaaa-bbbb-cccc-000000000000', '00000012-aaaa-bbbb-cccc-0000000000c7', 'Original complaint', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000013-aaaa-bbbb-cccc-000000000000', '00000013-aaaa-bbbb-cccc-0000000000d1', 'Initial Correspondence', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000014-aaaa-bbbb-cccc-000000000000', '00000014-aaaa-bbbb-cccc-0000000000ff', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL);
+                ('00000000-aaaa-bbbb-cccc-000000000000', '00000000-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000001-aaaa-bbbb-cccc-000000000000', '00000001-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'NOTUPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000002-aaaa-bbbb-cccc-000000000000', '00000002-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', NULL, 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000003-aaaa-bbbb-cccc-000000000000', '00000003-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'True', timestamp '2023-03-22 12:01:00'),
+                ('00000004-aaaa-bbbb-cccc-000000000000', '00000004-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 11:59:59', 'False', NULL),
+                ('00000005-aaaa-bbbb-cccc-000000000000', '00000005-aaaa-bbbb-cccc-0000000000a1', 'OTHERTYPE', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000006-aaaa-bbbb-cccc-000000000000', '00000006-aaaa-bbbb-cccc-0000000000a2', 'CONTRIBUTION', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000007-aaaa-bbbb-cccc-000000000000', '00000007-aaaa-bbbb-cccc-0000000000a3', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000008-aaaa-bbbb-cccc-000000000000', '00000008-aaaa-bbbb-cccc-0000000000a4', 'Original Complaint', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000009-aaaa-bbbb-cccc-000000000000', '00000009-aaaa-bbbb-cccc-0000000000a5', 'Contribution Response', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000010-aaaa-bbbb-cccc-000000000000', '00000010-aaaa-bbbb-cccc-0000000000a6', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000011-aaaa-bbbb-cccc-000000000000', '00000011-aaaa-bbbb-cccc-0000000000c5', 'Complaint leaflet', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000012-aaaa-bbbb-cccc-000000000000', '00000012-aaaa-bbbb-cccc-0000000000c7', 'Original complaint', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000013-aaaa-bbbb-cccc-000000000000', '00000013-aaaa-bbbb-cccc-0000000000d1', 'Initial Correspondence', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000014-aaaa-bbbb-cccc-000000000000', '00000014-aaaa-bbbb-cccc-0000000000ff', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000015-aaaa-bbbb-cccc-000000000000', '00000015-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'True', NULL);
             """;
         TestUtils.setUpPostgres(this.jdbcTemplate, insertRecords);
 

--- a/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/IngestScenario1Test.java
+++ b/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/IngestScenario1Test.java
@@ -68,14 +68,14 @@ public class IngestScenario1Test {
     void setUp() throws Exception {
         log.info("Test setUp");
         String insertRecords = """
-            INSERT INTO metadata.document_metadata (uuid, external_reference_uuid, type, pdf_link, status, updated_on, deleted_on)
+            INSERT INTO metadata.document_metadata (uuid, external_reference_uuid, type, pdf_link, status, updated_on, deleted, deleted_on)
             VALUES
-                ('00000000-aaaa-bbbb-cccc-000000000000', '00000000-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000001-aaaa-bbbb-cccc-000000000000', '00000001-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file2.pdf', 'UPLOADED', timestamp '2023-03-22 13:00:00', NULL),
-                ('00000002-aaaa-bbbb-cccc-000000000000', '00000002-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file3.pdf', 'UPLOADED', timestamp '2023-03-22 14:00:00', NULL),
-                ('00000003-aaaa-bbbb-cccc-000000000000', '00000003-aaaa-bbbb-cccc-000000000000', 'ORIGINAL', 'decs-file4.pdf', 'UPLOADED', timestamp '2023-03-22 15:00:00', NULL),
-                ('00000004-aaaa-bbbb-cccc-000000000000', '00000004-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file5.pdf', 'UPLOADED', timestamp '2023-03-22 16:00:00', NULL),
-                ('00000005-aaaa-bbbb-cccc-000000000000', '00000005-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file6.pdf', 'UPLOADED', timestamp '2023-03-22 17:00:00', NULL);
+                ('00000000-aaaa-bbbb-cccc-000000000000', '00000000-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000001-aaaa-bbbb-cccc-000000000000', '00000001-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file2.pdf', 'UPLOADED', timestamp '2023-03-22 13:00:00', 'False', NULL),
+                ('00000002-aaaa-bbbb-cccc-000000000000', '00000002-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file3.pdf', 'UPLOADED', timestamp '2023-03-22 14:00:00', 'False', NULL),
+                ('00000003-aaaa-bbbb-cccc-000000000000', '00000003-aaaa-bbbb-cccc-000000000000', 'ORIGINAL', 'decs-file4.pdf', 'UPLOADED', timestamp '2023-03-22 15:00:00', 'False', NULL),
+                ('00000004-aaaa-bbbb-cccc-000000000000', '00000004-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file5.pdf', 'UPLOADED', timestamp '2023-03-22 16:00:00', 'False', NULL),
+                ('00000005-aaaa-bbbb-cccc-000000000000', '00000005-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file6.pdf', 'UPLOADED', timestamp '2023-03-22 17:00:00', 'False', NULL);
             """;
         TestUtils.setUpPostgres(this.jdbcTemplate, insertRecords);
 

--- a/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/IngestScenario2Test.java
+++ b/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/IngestScenario2Test.java
@@ -86,14 +86,14 @@ public class IngestScenario2Test {
 
         log.info("Inserting mock data into database");
         String insertRecords = """
-            INSERT INTO metadata.document_metadata (WRONG_COLUMN, external_reference_uuid, type, pdf_link, status, updated_on, deleted_on)
+            INSERT INTO metadata.document_metadata (WRONG_COLUMN, external_reference_uuid, type, pdf_link, status, updated_on, deleted, deleted_on)
             VALUES
-                ('00000000-aaaa-bbbb-cccc-000000000000', '00000000-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000001-aaaa-bbbb-cccc-000000000000', '00000001-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file2.pdf', 'UPLOADED', timestamp '2023-03-22 13:00:00', NULL),
-                ('00000002-aaaa-bbbb-cccc-000000000000', '00000002-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file3.pdf', 'UPLOADED', timestamp '2023-03-22 14:00:00', NULL),
-                ('00000003-aaaa-bbbb-cccc-000000000000', '00000003-aaaa-bbbb-cccc-000000000000', 'ORIGINAL', 'decs-file4.pdf', 'UPLOADED', timestamp '2023-03-22 15:00:00', NULL),
-                ('00000004-aaaa-bbbb-cccc-000000000000', '00000004-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file5.pdf', 'UPLOADED', timestamp '2023-03-22 16:00:00', NULL),
-                ('00000005-aaaa-bbbb-cccc-000000000000', '00000005-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file6.pdf', 'UPLOADED', timestamp '2023-03-22 17:00:00', NULL);
+                ('00000000-aaaa-bbbb-cccc-000000000000', '00000000-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000001-aaaa-bbbb-cccc-000000000000', '00000001-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file2.pdf', 'UPLOADED', timestamp '2023-03-22 13:00:00', 'False', NULL),
+                ('00000002-aaaa-bbbb-cccc-000000000000', '00000002-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file3.pdf', 'UPLOADED', timestamp '2023-03-22 14:00:00', 'False', NULL),
+                ('00000003-aaaa-bbbb-cccc-000000000000', '00000003-aaaa-bbbb-cccc-000000000000', 'ORIGINAL', 'decs-file4.pdf', 'UPLOADED', timestamp '2023-03-22 15:00:00', 'False', NULL),
+                ('00000004-aaaa-bbbb-cccc-000000000000', '00000004-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file5.pdf', 'UPLOADED', timestamp '2023-03-22 16:00:00', 'False', NULL),
+                ('00000005-aaaa-bbbb-cccc-000000000000', '00000005-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file6.pdf', 'UPLOADED', timestamp '2023-03-22 17:00:00', 'False', NULL);
             """;
         this.jdbcTemplate.execute(insertRecords);
 

--- a/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/IngestScenario3Test.java
+++ b/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/IngestScenario3Test.java
@@ -64,14 +64,14 @@ public class IngestScenario3Test {
     void setUp() throws Exception {
         log.info("Test setUp");
         String insertRecords = """
-            INSERT INTO metadata.document_metadata (uuid, external_reference_uuid, type, pdf_link, status, updated_on, deleted_on)
+            INSERT INTO metadata.document_metadata (uuid, external_reference_uuid, type, pdf_link, status, updated_on, deleted, deleted_on)
             VALUES
-                ('00000000-aaaa-bbbb-cccc-000000000000', '00000000-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000001-aaaa-bbbb-cccc-000000000000', '00000001-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'NONEXISTENT-FILE.pdf', 'UPLOADED', timestamp '2023-03-22 13:00:00', NULL),
-                ('00000002-aaaa-bbbb-cccc-000000000000', '00000002-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file3.pdf', 'UPLOADED', timestamp '2023-03-22 14:00:00', NULL),
-                ('00000003-aaaa-bbbb-cccc-000000000000', '00000003-aaaa-bbbb-cccc-000000000000', 'ORIGINAL', 'decs-file4.pdf', 'UPLOADED', timestamp '2023-03-22 15:00:00', NULL),
-                ('00000004-aaaa-bbbb-cccc-000000000000', '00000004-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file5.pdf', 'UPLOADED', timestamp '2023-03-22 16:00:00', NULL),
-                ('00000005-aaaa-bbbb-cccc-000000000000', '00000005-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file6.pdf', 'UPLOADED', timestamp '2023-03-22 17:00:00', NULL);
+                ('00000000-aaaa-bbbb-cccc-000000000000', '00000000-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000001-aaaa-bbbb-cccc-000000000000', '00000001-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'NONEXISTENT-FILE.pdf', 'UPLOADED', timestamp '2023-03-22 13:00:00', 'False', NULL),
+                ('00000002-aaaa-bbbb-cccc-000000000000', '00000002-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file3.pdf', 'UPLOADED', timestamp '2023-03-22 14:00:00', 'False', NULL),
+                ('00000003-aaaa-bbbb-cccc-000000000000', '00000003-aaaa-bbbb-cccc-000000000000', 'ORIGINAL', 'decs-file4.pdf', 'UPLOADED', timestamp '2023-03-22 15:00:00', 'False', NULL),
+                ('00000004-aaaa-bbbb-cccc-000000000000', '00000004-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file5.pdf', 'UPLOADED', timestamp '2023-03-22 16:00:00', 'False', NULL),
+                ('00000005-aaaa-bbbb-cccc-000000000000', '00000005-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file6.pdf', 'UPLOADED', timestamp '2023-03-22 17:00:00', 'False', NULL);
             """;
         TestUtils.setUpPostgres(this.jdbcTemplate, insertRecords);
 

--- a/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/IngestScenario4Test.java
+++ b/src/integration-test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/IngestScenario4Test.java
@@ -67,14 +67,14 @@ public class IngestScenario4Test {
     void setUp() throws Exception {
         log.info("Test setUp");
         String insertRecords = """
-            INSERT INTO metadata.document_metadata (uuid, external_reference_uuid, type, pdf_link, status, updated_on, deleted_on)
+            INSERT INTO metadata.document_metadata (uuid, external_reference_uuid, type, pdf_link, status, updated_on, deleted, deleted_on)
             VALUES
-                ('00000000-aaaa-bbbb-cccc-000000000000', '00000000-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', NULL),
-                ('00000001-aaaa-bbbb-cccc-000000000000', '00000001-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file2.pdf', 'UPLOADED', timestamp '2023-03-22 13:00:00', NULL),
-                ('00000002-aaaa-bbbb-cccc-000000000000', '00000002-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file3.pdf', 'UPLOADED', timestamp '2023-03-22 14:00:00', NULL),
-                ('00000003-aaaa-bbbb-cccc-000000000000', '00000003-aaaa-bbbb-cccc-000000000000', 'ORIGINAL', 'decs-file4.pdf', 'UPLOADED', timestamp '2023-03-22 15:00:00', NULL),
-                ('00000004-aaaa-bbbb-cccc-000000000000', '00000004-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file5.pdf', 'UPLOADED', timestamp '2023-03-22 16:00:00', NULL),
-                ('00000005-aaaa-bbbb-cccc-000000000000', '00000005-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'NONEXISTENT-FILE.pdf', 'UPLOADED', timestamp '2023-03-22 17:00:00', NULL);
+                ('00000000-aaaa-bbbb-cccc-000000000000', '00000000-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file1.pdf', 'UPLOADED', timestamp '2023-03-22 12:00:00', 'False', NULL),
+                ('00000001-aaaa-bbbb-cccc-000000000000', '00000001-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file2.pdf', 'UPLOADED', timestamp '2023-03-22 13:00:00', 'False', NULL),
+                ('00000002-aaaa-bbbb-cccc-000000000000', '00000002-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file3.pdf', 'UPLOADED', timestamp '2023-03-22 14:00:00', 'False', NULL),
+                ('00000003-aaaa-bbbb-cccc-000000000000', '00000003-aaaa-bbbb-cccc-000000000000', 'ORIGINAL', 'decs-file4.pdf', 'UPLOADED', timestamp '2023-03-22 15:00:00', 'False', NULL),
+                ('00000004-aaaa-bbbb-cccc-000000000000', '00000004-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'decs-file5.pdf', 'UPLOADED', timestamp '2023-03-22 16:00:00', 'False', NULL),
+                ('00000005-aaaa-bbbb-cccc-000000000000', '00000005-aaaa-bbbb-cccc-0000000000a1', 'ORIGINAL', 'NONEXISTENT-FILE.pdf', 'UPLOADED', timestamp '2023-03-22 17:00:00', 'False', NULL);
             """;
         TestUtils.setUpPostgres(this.jdbcTemplate, insertRecords);
 

--- a/src/main/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/batch/PostgresItemReader.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/batch/PostgresItemReader.java
@@ -103,6 +103,7 @@ public class PostgresItemReader extends JdbcCursorItemReader<DocumentRow> {
                     status in ('UPLOADED')
                     AND pdf_link IS NOT NULL
                     AND deleted_on IS NULL
+                    AND deleted != True
                     AND updated_on > '$timestamp'::timestamp
             )
             SELECT
@@ -161,6 +162,7 @@ public class PostgresItemReader extends JdbcCursorItemReader<DocumentRow> {
                 WHERE
                     status in ('UPLOADED')
                     AND pdf_link IS NOT NULL
+                    AND deleted = True
                     AND deleted_on > '$timestamp'::timestamp - interval '1 week'
             )
             SELECT

--- a/src/main/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/documents/DocumentRowMapper.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/documents/DocumentRowMapper.java
@@ -35,7 +35,7 @@ public class DocumentRowMapper implements RowMapper<DocumentRow>{
         document.setUpdatedOn(rs.getTimestamp("updated_on"));
         document.setDeletedOn(rs.getTimestamp("deleted_on"));
 
-        String destinationKey = computeDestinationKey(document.getUpdatedOn(), document.getPdfLink());
+        String destinationKey = computeDestinationKey(document.getUuid(), document.getExternalReferenceUuid(), document.getUpdatedOn());
         document.setDestinationKey(destinationKey);
 
         document.setSource(this.hocsSystem);
@@ -43,7 +43,7 @@ public class DocumentRowMapper implements RowMapper<DocumentRow>{
         return document;
     }
 
-    public String computeDestinationKey(Timestamp updatedOn, String pdfLink) {
+    public String computeDestinationKey(String uuid, String extRefUuid, Timestamp updatedOn) {
         /*
         Craft the path where objects will be written to in the destination S3 bucket.
 
@@ -53,10 +53,11 @@ public class DocumentRowMapper implements RowMapper<DocumentRow>{
         String year = "year=" + dateTime.format(yearFormatter);
         String month = "month=" + dateTime.format(monthFormatter);
         String day = "day=" + dateTime.format(dayFormatter);
+        String uuidWithExtension = uuid + ".pdf";
 
         StringJoiner joiner = new StringJoiner("/");
-        // example destinationKey: decs/cs/year=2023/month=07/day=28/pdfLink
-        joiner.add("decs").add(this.hocsSystem).add(year).add(month).add(day).add(pdfLink);
+        // example destinationKey: decs/cs/year=2023/month=07/day=28/externalReferenceUuid/uuid.pdf
+        joiner.add("decs").add(this.hocsSystem).add(year).add(month).add(day).add(extRefUuid).add(uuidWithExtension);
         return joiner.toString();
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/documents/DocumentRowMapperTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/hocstxadocumentextractor/documents/DocumentRowMapperTest.java
@@ -54,7 +54,7 @@ public class DocumentRowMapperTest {
         assertEquals(doc.getStatus(), status);
         assertEquals(doc.getUpdatedOn(), updatedOn);
         assertEquals(doc.getDeletedOn(), deletedOn);
-        assertEquals(doc.getDestinationKey(), "decs/cs/year=2007/month=09/day=23/some-file.pdf");
+        assertEquals(doc.getDestinationKey(), "decs/cs/year=2007/month=09/day=23/00000000-aaaa-bbbb-cccc-0000000000a1/00000000-aaaa-bbbb-cccc-000000000000.pdf");
         assertEquals(doc.getSource(), "cs");
     }
 
@@ -65,9 +65,10 @@ public class DocumentRowMapperTest {
          */
         DocumentRowMapper docMap = new DocumentRowMapper("cs");
         java.sql.Timestamp timestamp = java.sql.Timestamp.valueOf("2023-12-12 10:10:10.0");
-        String pdfLink = "a1-b2-c3/d4-e5-f6.pdf";
-        String result = docMap.computeDestinationKey(timestamp, pdfLink);
-        String expected = "decs/cs/year=2023/month=12/day=12/a1-b2-c3/d4-e5-f6.pdf";
+        String uuid = "a1-b2-c3";
+        String externalReferenceUuid = "d4-e5-f6";
+        String result = docMap.computeDestinationKey(uuid, externalReferenceUuid, timestamp);
+        String expected = "decs/cs/year=2023/month=12/day=12/d4-e5-f6/a1-b2-c3.pdf";
         assertEquals(expected, result);
     }
 
@@ -78,9 +79,10 @@ public class DocumentRowMapperTest {
          */
         DocumentRowMapper docMap = new DocumentRowMapper("wcs");
         java.sql.Timestamp timestamp = java.sql.Timestamp.valueOf("2023-1-9 10:10:10.0");
-        String pdfLink = "a1-b2-c3/d4-e5-f6.pdf";
-        String result = docMap.computeDestinationKey(timestamp, pdfLink);
-        String expected = "decs/wcs/year=2023/month=01/day=09/a1-b2-c3/d4-e5-f6.pdf";
+        String uuid = "a1-b2-c3";
+        String externalReferenceUuid = "d4-e5-f6";
+        String result = docMap.computeDestinationKey(uuid, externalReferenceUuid, timestamp);
+        String expected = "decs/wcs/year=2023/month=01/day=09/d4-e5-f6/a1-b2-c3.pdf";
         assertEquals(expected, result);
 
     }


### PR DESCRIPTION
Updated the postgres RDS SQL queries to prevent documents with deleted=True but deleted_on=NULL from being collected for ingest. Updated associated integration tests.

Also updated the computeDestinationKey function to explicitly include the uuid/externalReferenceUuid in the path where documents get written in the text analytics S3 bucket. Updated associated unit tests.